### PR TITLE
Add a PNG output to LegendRenderer

### DIFF
--- a/src/LegendRenderer/AbstractOutput.ts
+++ b/src/LegendRenderer/AbstractOutput.ts
@@ -1,0 +1,21 @@
+abstract class AbstractOutput {
+  protected constructor(
+    protected size: [number, number],
+    protected maxColumnWidth: number | null,
+    protected maxColumnHeight: number | null
+  ) {}
+  abstract useContainer(title: string): void;
+  abstract useRoot(): void;
+  abstract addTitle(text: string, x: number|string, y: number|string): void;
+  abstract addLabel(text: string, x: number|string, y: number|string): void;
+  abstract addImage(
+    dataUrl: string,
+    imgWidth: number,
+    imgHeight: number,
+    x: number|string,
+    y: number|string,
+    drawRect: boolean,
+  ): void;
+  abstract generate(finalHeight: number): Element;
+}
+export default AbstractOutput;

--- a/src/LegendRenderer/LegendRenderer.spec.ts
+++ b/src/LegendRenderer/LegendRenderer.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import LegendRenderer from './LegendRenderer';
-import { select } from 'd3-selection';
 
 describe('LegendRenderer', () => {
 

--- a/src/LegendRenderer/LegendRenderer.spec.ts
+++ b/src/LegendRenderer/LegendRenderer.spec.ts
@@ -1,6 +1,23 @@
 /* eslint-env jest */
 
 import LegendRenderer from './LegendRenderer';
+import AbstractOutput from './AbstractOutput';
+
+class MockOutput extends AbstractOutput {
+  constructor(
+    protected size: [number, number],
+    protected maxColumnWidth: number | null,
+    protected maxColumnHeight: number | null
+  ) {
+    super(size, maxColumnWidth, maxColumnHeight);
+  }
+  useContainer = jest.fn();
+  useRoot = jest.fn();
+  addTitle = jest.fn();
+  addLabel = jest.fn();
+  addImage = jest.fn();
+  generate = jest.fn();
+}
 
 describe('LegendRenderer', () => {
 
@@ -78,8 +95,8 @@ describe('LegendRenderer', () => {
     const renderer = new LegendRenderer({
       size: [0, 0]
     });
-    const dom: any = document.createElement('svg');
-    const returnValue = await renderer.renderLegendItem(select(<SVGGElement> dom), {
+    const output = new MockOutput([0, 0], undefined, undefined);
+    const returnValue = await renderer.renderLegendItem(output, {
       title: 'Example',
       rule: {
         name: 'Item 1',
@@ -91,12 +108,12 @@ describe('LegendRenderer', () => {
     expect(returnValue).toBeUndefined();
   });
 
-  it('renders a single non-empty legend item', done => {
+  it('renders a single non-empty legend item', async () => {
     const renderer = new LegendRenderer({
       size: [0, 0]
     });
-    const dom: any = document.createElement('svg');
-    const result = renderer.renderLegendItem(select(<SVGGElement> dom), {
+    const output = new MockOutput([0, 0], undefined, undefined);
+    await renderer.renderLegendItem(output, {
       title: 'Example',
       rule: {
         name: 'Item 1',
@@ -106,10 +123,8 @@ describe('LegendRenderer', () => {
         }]
       }
     }, [0, 0]);
-    result.then(() => {
-      expect(dom.querySelector('text').textContent).toBe('Example');
-      done();
-    });
+    expect(output.useContainer).toHaveBeenCalledWith('Example');
+    expect(output.addLabel).toHaveBeenCalledWith('Example', 50, 20);
   });
 
   it('renders legend with a single non-empty legend item', done => {

--- a/src/LegendRenderer/LegendRenderer.ts
+++ b/src/LegendRenderer/LegendRenderer.ts
@@ -15,7 +15,7 @@ import OlStyleParser from 'geostyler-openlayers-parser';
 import OlFeature from 'ol/Feature';
 import SvgOutput from './SvgOutput';
 import AbstractOutput from './AbstractOutput';
-import PngOutput from './PngOutput'
+import PngOutput from './PngOutput';
 
 interface LegendItemConfiguration {
   rule?: Rule;

--- a/src/LegendRenderer/LegendRenderer.ts
+++ b/src/LegendRenderer/LegendRenderer.ts
@@ -318,7 +318,7 @@ class LegendRenderer {
   }
 
   /**
-   * Renders the configured legend as an SVG image in the given target container. All pre-existing legends
+   * Renders the configured legend as an SVG or PNG image in the given target container. All pre-existing legends
    * will be removed.
    * @param {HTMLElement} target a node to append the svg to
    * @param format

--- a/src/LegendRenderer/LegendRenderer.ts
+++ b/src/LegendRenderer/LegendRenderer.ts
@@ -1,5 +1,3 @@
-import { select, Selection, BaseType } from 'd3-selection';
-
 import { boundingExtent } from 'ol/extent';
 import OlGeometry from 'ol/geom/Geometry';
 import OlGeomPoint from 'ol/geom/Point';
@@ -15,6 +13,8 @@ import {
 } from 'geostyler-style';
 import OlStyleParser from 'geostyler-openlayers-parser';
 import OlFeature from 'ol/Feature';
+import SvgOutput from './SvgOutput';
+import AbstractOutput from './AbstractOutput';
 
 interface LegendItemConfiguration {
   rule?: Rule;
@@ -42,10 +42,10 @@ interface LegendsConfiguration {
   hideRect?: boolean;
 }
 
-const iconSize = [45, 30];
+const iconSize: [number, number] = [45, 30];
 
 /**
- * A class that can be used to render svg legends.
+ * A class that can be used to render legends as images.
  */
 class LegendRenderer {
 
@@ -82,12 +82,12 @@ class LegendRenderer {
 
   /**
    * Renders a single legend item.
-   * @param {Selection} container the container to append the legend item to
+   * @param {AbstractOutput} output
    * @param {LegendItemConfiguration} item configuration of the legend item
    * @param {[number, number]} position the current position
    */
   renderLegendItem(
-    container: Selection<SVGGElement, {}, null, undefined>,
+    output: AbstractOutput,
     item: LegendItemConfiguration,
     position: [number, number]
   ) {
@@ -99,30 +99,11 @@ class LegendRenderer {
     } = this.config;
 
     if (item.rule) {
-      container = container.append('g')
-        .attr('class', 'legend-item')
-        .attr('title', item.title);
+      output.useContainer(item.title);
       return this.getRuleIcon(item.rule)
         .then((uri) => {
-          if (!hideRect) {
-            container.append('rect')
-              .attr('x', position[0] + 1)
-              .attr('y', position[1])
-              .attr('width', iconSize[0])
-              .attr('height', iconSize[1])
-              .style('fill-opacity', 0)
-              .style('stroke', 'black');
-          }
-          container.append('image')
-            .attr('x', position[0] + 1)
-            .attr('y', position[1])
-            .attr('width', iconSize[0])
-            .attr('height', iconSize[1])
-            .attr('href', uri);
-          container.append('text')
-            .text(item.title)
-            .attr('x', position[0] + iconSize[0] + 5)
-            .attr('y', position[1] + 20);
+          output.addImage(uri, ...iconSize, position[0] + 1, position[1], !hideRect);
+          output.addLabel(item.title, position[0] + iconSize[0] + 5, position[1] + 20);
           position[1] += iconSize[1] + 5;
           if (maxColumnHeight && position[1] + iconSize[1] + 5 >= maxColumnHeight) {
             position[1] = 5;
@@ -134,36 +115,6 @@ class LegendRenderer {
         });
     }
     return undefined;
-  }
-
-  /**
-   * Shortens the labels if they overflow.
-   * @param {Selection} nodes the legend item group nodes
-   * @param {number} maxWidth the maximum column width
-   */
-  shortenLabels(nodes: Selection<BaseType, {}, SVGSVGElement, {}>, maxWidth: number) {
-    nodes.each(function() {
-      const node = select(this);
-      const text = node.select('text');
-      if (!(node.node() instanceof SVGElement)) {
-        return;
-      }
-      const elem: Element = <Element> (node.node());
-      let width = elem.getBoundingClientRect().width;
-      let adapted = false;
-      while (width > maxWidth) {
-        let str = text.text();
-        str = str.substring(0, str.length - 1);
-        text.text(str);
-        width = elem.getBoundingClientRect().width;
-        adapted = true;
-      }
-      if (adapted) {
-        let str = text.text();
-        str = str.substring(0, str.length - 3);
-        text.text(str + '...');
-      }
-    });
   }
 
   /**
@@ -250,15 +201,15 @@ class LegendRenderer {
   /**
    * Render a single legend.
    * @param {LegendConfiguration} config the legend config
-   * @param {Selection} svg the root node
+   * @param {AbstractOutput} output
    * @param {[number, number]} position the current position
    */
   renderLegend(
     config: LegendConfiguration,
-    svg: Selection<SVGSVGElement, {}, null, undefined>,
+    output: AbstractOutput,
     position: [number, number]
   ) {
-    const container = svg.append('g');
+    output.useRoot();
     if (this.config.overflow !== 'auto' && position[0] !== 0) {
       const legendHeight = config.items.length * (iconSize[1] + 5) + 20;
       if (legendHeight + position[1] > this.config.maxColumnHeight) {
@@ -267,29 +218,24 @@ class LegendRenderer {
       }
     }
     if (config.title) {
-      container.append('text')
-        .text(config.title)
-        .attr('class', 'legend-title')
-        .attr('text-anchor', 'start')
-        .attr('dx', position[0])
-        .attr('dy', position[1] === 0 ? '1em': position[1] + 15);
+      output.addTitle(config.title, position[0], position[1] === 0 ? '1em': position[1] + 15);
       position[1] += 20;
     }
 
     return config.items.reduce((cur, item) => {
-      return cur.then(() => this.renderLegendItem(svg, item, position));
+      return cur.then(() => this.renderLegendItem(output, item, position));
     }, Promise.resolve());
   }
 
   /**
    * Render all images given by URL and append them to the legend
    * @param {RemoteLegend[]} remoteLegends the array of remote legend objects
-   * @param {Selection} svg the root node
+   * @param {AbstractOutput} output
    * @param {[number, number]} position the current position
    */
   async renderImages(
     remoteLegends: RemoteLegend[],
-    svg: Selection<SVGSVGElement, {}, null, undefined>,
+    output: AbstractOutput,
     position: [number, number]
   ) {
     const legendSpacing = 20;
@@ -327,30 +273,19 @@ class LegendRenderer {
           position[1] = 0;
         }
         if (legendTitle) {
-          const container = svg.append('g');
+          output.useRoot();
           position[1] += legendSpacing;
-          container.append('text')
-            .text(legendTitle)
-            .attr('class', 'legend-title')
-            .attr('text-anchor', 'start')
-            .attr('dx', position[0])
-            .attr('dy', position[1]);
+          output.addTitle(legendTitle, ...position);
           position[1] += titleSpacing;
         }
-        svg.append('svg:image')
-          .attr('x', position[0])
-          .attr('y', position[1])
-          .attr('width', img.width)
-          .attr('height', img.height)
-          .attr('href', base64.toString());
+        output.addImage(base64.toString(), img.width, img.height,...position, false);
 
         position[1] += img.height;
       } catch (err) {
         console.error('Error on fetching legend: ', err);
         continue;
       }
-    };
-    svg.attr('xmlns', 'http://www.w3.org/2000/svg');
+    }
   }
 
   /**
@@ -363,7 +298,9 @@ class LegendRenderer {
       styles,
       configs,
       size: [width, height],
-      remoteLegends
+      remoteLegends,
+      maxColumnWidth,
+      maxColumnHeight,
     } = this.config;
     const legends: LegendConfiguration[] = [];
     if (styles) {
@@ -372,35 +309,15 @@ class LegendRenderer {
     if (configs) {
       legends.unshift.apply(legends, configs);
     }
-
-    const svgClass = 'geostyler-legend-renderer';
-    const parent = select(target);
-    parent.select(`.${svgClass}`).remove();
-
-    const svg = parent
-      .append('svg')
-      .attr('class', svgClass)
-      .attr('viewBox', `0 0 ${width} ${height}`)
-      .attr('top', 0)
-      .attr('left', 0)
-      .attr('width', width)
-      .attr('height', height);
-
+    const svgOutput = new SvgOutput(target, [width, height], maxColumnWidth, maxColumnHeight);
     const position: [number, number] = [0, 0];
     for (let i = 0; i < legends.length; i++) {
-      await this.renderLegend(legends[i], svg, position);
-    };
+      await this.renderLegend(legends[i], svgOutput, position);
+    }
     if (remoteLegends) {
-      await this.renderImages(remoteLegends, svg, position);
+      await this.renderImages(remoteLegends, svgOutput, position);
     }
-    const nodes = svg.selectAll('g.legend-item');
-    this.shortenLabels(nodes, this.config.maxColumnWidth);
-    if (!this.config.maxColumnHeight) {
-      svg
-        .attr('viewBox', `0 0 ${width} ${position[1]}`)
-        .attr('height', position[1]);
-    }
-    return svg;
+    return svgOutput.generate(position[1]);
   }
 }
 export default LegendRenderer;

--- a/src/LegendRenderer/PngOutput.spec.ts
+++ b/src/LegendRenderer/PngOutput.spec.ts
@@ -1,0 +1,128 @@
+/* eslint-env jest */
+
+import PngOutput from './PngOutput';
+import {
+  makeSampleOutput,
+  SAMPLE_OUTPUT_FINAL_HEIGHT,
+  SAMPLE_PNG_EVENTS,
+  SAMPLE_PNG_EVENTS_HEIGHT_TOO_LOW
+} from '../fixtures/outputs';
+
+function instrumentContext(context: CanvasRenderingContext2D) {
+  context.drawImage = jest.fn(context.drawImage) as any;
+  context.fillText = jest.fn(context.fillText) as any;
+  context.strokeRect = jest.fn(context.strokeRect) as any;
+}
+
+function getContextEvents(context: CanvasRenderingContext2D) {
+  // eslint-disable-next-line no-underscore-dangle
+  return (context as any).__getEvents();
+}
+
+describe('PngOutput', () => {
+  let output: PngOutput;
+
+  it('is defined', () => {
+    expect(PngOutput).not.toBeUndefined();
+  });
+
+  describe('individual actions', () => {
+    beforeEach(() => {
+      output = new PngOutput([500, 700], undefined, undefined);
+      instrumentContext(output.context);
+    });
+
+    describe('#useContainer', () => {
+      it('does nothing', () => {
+        output.useContainer('My Container');
+        // succeed
+      });
+    });
+    describe('#useRoot', () => {
+      it('does nothing', () => {
+        output.useContainer('My Container');
+        output.useRoot();
+        // succeed
+      });
+    });
+    describe('#addTitle', () => {
+      it('inserts a title', () => {
+        output.addTitle('My Title', 100, 150);
+        expect(output.context.fillText).toHaveBeenCalledWith('My Title', 100, 150);
+        expect(output.context.fillStyle).toEqual('#000000');
+      });
+    });
+    describe('#addLabel', () => {
+      it('inserts a label', () => {
+        output.addLabel('My Label', 100, 150);
+        expect(output.context.fillText).toHaveBeenCalledWith('My Label', 100, 150);
+        expect(output.context.fillStyle).toEqual('#000000');
+      });
+    });
+    describe('#addImage', () => {
+      it('inserts an image (no frame)', () => {
+        output.addImage('bla', 100, 50, 200, 250, false);
+        const calledImg = (output.context.drawImage as any).mock.calls[0][0];
+        expect(output.context.drawImage).toHaveBeenCalledWith(expect.any(Image), 200, 250, 100, 50);
+        expect(calledImg.src).toBe('http://localhost/bla');
+        expect(output.context.strokeRect).not.toHaveBeenCalled();
+        expect(output.context.strokeStyle).toEqual('#000000');
+      });
+      it('inserts an image (with frame)', () => {
+        output.addImage('bla', 100, 50, 200, 250, true);
+        const calledImg = (output.context.drawImage as any).mock.calls[0][0];
+        expect(output.context.drawImage).toHaveBeenCalledWith(expect.any(Image), 200, 250, 100, 50);
+        expect(calledImg.src).toBe('http://localhost/bla');
+        expect(output.context.strokeRect).toHaveBeenCalledWith(200, 250, 100, 50);
+        expect(output.context.strokeStyle).toEqual('#000000');
+      });
+    });
+  });
+
+  describe('without column constraints', () => {
+    beforeEach(() => {
+      output = new PngOutput([500, 700], undefined, undefined);
+      makeSampleOutput(output);
+    });
+    it('generates the right output', () => {
+      const canvas = output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT);
+      expect(getContextEvents(canvas.getContext('2d'))).toEqual(SAMPLE_PNG_EVENTS);
+    });
+  });
+
+  describe('with column constraints', () => {
+    beforeEach(() => {
+      output = new PngOutput([500, 700], 50, 200);
+      makeSampleOutput(output);
+    });
+    it('generates the same output as without constraints', () => {
+      const canvas = output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT);
+      expect(getContextEvents(canvas.getContext('2d'))).toEqual(SAMPLE_PNG_EVENTS);
+    });
+  });
+
+  describe('with a height too low', () => {
+    beforeEach(() => {
+      output = new PngOutput([500, 200], 50, 200);
+      makeSampleOutput(output);
+    });
+    it('resizes the final canvas', () => {
+      const canvas = output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT);
+      expect(getContextEvents(canvas.getContext('2d'))).toEqual(SAMPLE_PNG_EVENTS_HEIGHT_TOO_LOW);
+    });
+  });
+
+  describe('when a target is given', () => {
+    let root: HTMLDivElement;
+    beforeEach(() => {
+      root = document.createElement('div');
+      output = new PngOutput([500, 700], 250, 500, root);
+    });
+    it('appends the output to the target element', () => {
+      output.generate(123);
+      expect(root.children.item(0).outerHTML).toEqual(
+        '<canvas class="geostyler-legend-renderer" width="500" height="700"></canvas>'
+      );
+    });
+  });
+});

--- a/src/LegendRenderer/PngOutput.spec.ts
+++ b/src/LegendRenderer/PngOutput.spec.ts
@@ -32,19 +32,6 @@ describe('PngOutput', () => {
       instrumentContext(output.context);
     });
 
-    describe('#useContainer', () => {
-      it('does nothing', () => {
-        output.useContainer('My Container');
-        // succeed
-      });
-    });
-    describe('#useRoot', () => {
-      it('does nothing', () => {
-        output.useContainer('My Container');
-        output.useRoot();
-        // succeed
-      });
-    });
     describe('#addTitle', () => {
       it('inserts a title', () => {
         output.addTitle('My Title', 100, 150);

--- a/src/LegendRenderer/PngOutput.ts
+++ b/src/LegendRenderer/PngOutput.ts
@@ -1,0 +1,52 @@
+import AbstractOutput from './AbstractOutput';
+
+const ROOT_CLASS = 'geostyler-legend-renderer';
+
+export default class PngOutput extends AbstractOutput {
+  canvas: HTMLCanvasElement;
+
+  constructor(
+    size: [number, number],
+    maxColumnWidth: number | null,
+    maxColumnHeight: number | null,
+    private target?: HTMLElement,
+  ) {
+    super(size, maxColumnWidth, maxColumnHeight);
+    this.canvas = document.createElement('canvas');
+    this.canvas.className = ROOT_CLASS;
+    this.canvas.width = size[0];
+    this.canvas.height = size[1];
+    if (this.target) {
+      target.querySelectorAll(`.${ROOT_CLASS}`).forEach(e => e.remove());
+      target.append(this.canvas);
+    }
+  }
+
+  useContainer(title: string) {
+  }
+
+  useRoot() {
+  }
+
+  addTitle(text: string, x: number | string, y: number | string) {
+  }
+
+  addLabel(text: string, x: number | string, y: number | string) {
+  }
+
+  addImage(
+    dataUrl: string,
+    imgWidth: number,
+    imgHeight: number,
+    x: number|string,
+    y: number|string,
+    drawRect: boolean,
+  ) {
+  }
+
+  generate(finalHeight: number) {
+    const ctx = this.canvas.getContext('2d');
+    ctx.fillText(`Hello world! size = ${this.size[0]}x${this.size[1]}`, 20, 20);
+    return this.canvas;
+  }
+}

--- a/src/LegendRenderer/SvgOutput.spec.ts
+++ b/src/LegendRenderer/SvgOutput.spec.ts
@@ -1,0 +1,142 @@
+/* eslint-env jest */
+
+import SvgOutput from './SvgOutput';
+import {
+  makeSampleOutput,
+  SAMPLE_SVG,
+  SAMPLE_SVG_COLUMN_CONSTRAINTS,
+  SAMPLE_OUTPUT_FINAL_HEIGHT
+} from '../fixtures/outputs';
+
+// mock getBoundingClientRect on created DOM elements
+// (by default jsdom always return 0 so there's no way to test label shortening)
+(document as any).originalCreateElementNS = document.createElementNS;
+document.createElementNS = function(namespace: string, eltName: string) {
+  const el = (document as any).originalCreateElementNS(namespace, eltName);
+  el.getBoundingClientRect = function(): DOMRect {
+    const charCount = this.textContent.length;
+    return {
+      height: 10,
+      width: charCount * 6,
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      bottom: 0,
+      right: 0,
+      toJSON: () => ''
+    };
+  };
+  return el;
+};
+
+describe('SvgOutput', () => {
+  let output: SvgOutput;
+
+  it('is defined', () => {
+    expect(SvgOutput).not.toBeUndefined();
+  });
+
+  describe('individual actions', () => {
+    beforeEach(() => {
+      output = new SvgOutput([500, 700], undefined, undefined);
+    });
+
+    describe('#useContainer', () => {
+      it('inserts elements in a container', () => {
+        output.useContainer('My Container');
+        output.addImage('bla', 100, 50, 200, 250, false);
+        expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).innerHTML).toContain(
+          '<g class="legend-item" title="My Container"><image'
+        );
+      });
+    });
+    describe('#useRoot', () => {
+      it('closes container and inserts elements at the root', () => {
+        output.useContainer('My Container');
+        output.useRoot();
+        output.addImage('bla', 100, 50, 200, 250, false);
+        expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).innerHTML).toContain(
+          '<g class="legend-item" title="My Container"></g><image'
+        );
+      });
+    });
+    describe('#addTitle', () => {
+      it('inserts a title', () => {
+        output.addTitle('My Title', 100, 150);
+        expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).innerHTML).toEqual(
+          '<g><text class="legend-title" text-anchor="start" dx="100" dy="150">My Title</text></g>'
+        );
+      });
+    });
+    describe('#addLabel', () => {
+      it('inserts a label', () => {
+        output.addLabel('My Label', 100, 150);
+        expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).innerHTML).toEqual(
+          '<text x="100" y="150">My Label</text>'
+        );
+      });
+    });
+    describe('#addImage', () => {
+      it('inserts an image (no frame)', () => {
+        output.addImage('bla', 100, 50, 200, 250, false);
+        expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).innerHTML).toEqual(
+          '<image x="200" y="250" width="100" height="50" href="bla"></image>'
+        );
+      });
+      it('inserts an image (with frame)', () => {
+        output.addImage('bla', 100, 50, 200, 250, true);
+        expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).innerHTML).toEqual(
+          '<rect x="200" y="250" width="100" height="50" style="fill-opacity: 0; stroke: black;"></rect>' +
+          '<image x="200" y="250" width="100" height="50" href="bla"></image>'
+        );
+      });
+    });
+  });
+
+  describe('without column constraints', () => {
+    beforeEach(() => {
+      output = new SvgOutput([500, 700], undefined, undefined);
+      makeSampleOutput(output);
+    });
+    it('generates the right output', () => {
+      expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).outerHTML).toEqual(SAMPLE_SVG);
+    });
+  });
+
+  describe('with column constraints', () => {
+    beforeEach(() => {
+      output = new SvgOutput([500, 700], 50, 200);
+      makeSampleOutput(output);
+    });
+    it('generates the right output', () => {
+      expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).outerHTML).toEqual(SAMPLE_SVG_COLUMN_CONSTRAINTS);
+    });
+  });
+
+  describe('with a height too low', () => {
+    beforeEach(() => {
+      output = new SvgOutput([500, 200], 50, 200);
+      makeSampleOutput(output);
+    });
+    it('sets the height on the final canvas', () => {
+      expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).outerHTML).toEqual(SAMPLE_SVG_COLUMN_CONSTRAINTS
+        .replace('viewBox="0 0 500 700" top="0" left="0" width="500" height="700"',
+          'viewBox="0 0 500 200" top="0" left="0" width="500" height="200"'));
+    });
+  });
+
+  describe('when a target is given', () => {
+    let root: HTMLDivElement;
+    beforeEach(() => {
+      root = document.createElement('div');
+      output = new SvgOutput([500, 700], 250, 500, root);
+    });
+    it('appends the output to the target element', () => {
+      output.generate(123);
+      expect(root.children.item(0).outerHTML).toEqual(
+        '<svg class="geostyler-legend-renderer" viewBox="0 0 500 700" top="0" left="0" width="500" height="700"></svg>'
+      );
+    });
+  });
+});

--- a/src/LegendRenderer/SvgOutput.ts
+++ b/src/LegendRenderer/SvgOutput.ts
@@ -1,0 +1,123 @@
+import {BaseType, select, Selection} from 'd3-selection';
+import AbstractOutput from './AbstractOutput';
+
+export default class SvgOutput extends AbstractOutput {
+  root: Selection<SVGSVGElement, {}, null, undefined> = null;
+  currentContainer: Selection<SVGGElement, {}, null, undefined> = null;
+
+  constructor(
+    target: HTMLElement,
+    size: [number, number],
+    maxColumnWidth: number | null,
+    maxColumnHeight: number | null
+  ) {
+    super(size, maxColumnWidth, maxColumnHeight);
+
+    const svgClass = 'geostyler-legend-renderer';
+    const parent = select(target);
+    parent.select(`.${svgClass}`).remove();
+
+    this.root = parent
+      .append('svg')
+      .attr('class', svgClass)
+      .attr('viewBox', `0 0 ${size[0]} ${size[1]}`)
+      .attr('top', 0)
+      .attr('left', 0)
+      .attr('width', size[0])
+      .attr('height', size[1]);
+    this.currentContainer = this.root;
+  }
+
+  useContainer(title: string) {
+    this.currentContainer = this.root.append('g')
+      .attr('class', 'legend-item')
+      .attr('title', title);
+  };
+
+  useRoot() {
+    this.currentContainer = this.root;
+  }
+
+  addTitle(text: string, x: number | string, y: number | string) {
+    this.currentContainer.append('g').append('text')
+      .text(text)
+      .attr('class', 'legend-title')
+      .attr('text-anchor', 'start')
+      .attr('dx', x)
+      .attr('dy', y);
+  };
+
+  addLabel(text: string, x: number | string, y: number | string) {
+    this.currentContainer.append('text')
+      .text(text)
+      .attr('x', x)
+      .attr('y', y);
+  };
+
+  addImage(
+    dataUrl: string,
+    imgWidth: number,
+    imgHeight: number,
+    x: number|string,
+    y: number|string,
+    drawRect: boolean,
+  ) {
+    if (drawRect) {
+      this.currentContainer.append('rect')
+        .attr('x', x)
+        .attr('y', y)
+        .attr('width', imgWidth)
+        .attr('height', imgHeight)
+        .style('fill-opacity', 0)
+        .style('stroke', 'black');
+    }
+    this.currentContainer.append('svg:image')
+      .attr('x', x)
+      .attr('y', y)
+      .attr('width', imgWidth)
+      .attr('height', imgHeight)
+      .attr('href', dataUrl);
+    this.root.attr('xmlns', 'http://www.w3.org/2000/svg');
+  };
+
+  /**
+   * Shortens the labels if they overflow.
+   * @param {Selection} nodes the legend item group nodes
+   * @param {number} maxWidth the maximum column width
+   */
+  private shortenLabels(nodes: Selection<BaseType, {}, SVGElement, {}>, maxWidth: number) {
+    nodes.each(function() {
+      const node = select(this);
+      const text = node.select('text');
+      if (!(node.node() instanceof SVGElement)) {
+        return;
+      }
+      const elem: Element = <Element> (node.node());
+      let width = elem.getBoundingClientRect().width;
+      let adapted = false;
+      while (width > maxWidth) {
+        let str = text.text();
+        str = str.substring(0, str.length - 1);
+        text.text(str);
+        width = elem.getBoundingClientRect().width;
+        adapted = true;
+      }
+      if (adapted) {
+        let str = text.text();
+        str = str.substring(0, str.length - 3);
+        text.text(str + '...');
+      }
+    });
+  }
+
+  generate(finalHeight: number) {
+    const nodes = this.root.selectAll('g.legend-item');
+    this.shortenLabels(nodes, this.maxColumnWidth);
+    if (!this.maxColumnHeight) {
+      this.root
+        .attr('viewBox', `0 0 ${this.size[0]} ${finalHeight}`)
+        .attr('height', finalHeight);
+    }
+    return this.root.node() as SVGElement;
+  }
+}

--- a/src/LegendRenderer/SvgOutput.ts
+++ b/src/LegendRenderer/SvgOutput.ts
@@ -1,31 +1,35 @@
 import {BaseType, select, Selection} from 'd3-selection';
 import AbstractOutput from './AbstractOutput';
 
+const ROOT_CLASS = 'geostyler-legend-renderer';
+
 export default class SvgOutput extends AbstractOutput {
   root: Selection<SVGSVGElement, {}, null, undefined> = null;
   currentContainer: Selection<SVGGElement, {}, null, undefined> = null;
 
   constructor(
-    target: HTMLElement,
     size: [number, number],
     maxColumnWidth: number | null,
-    maxColumnHeight: number | null
+    maxColumnHeight: number | null,
+    target?: HTMLElement,
   ) {
     super(size, maxColumnWidth, maxColumnHeight);
 
-    const svgClass = 'geostyler-legend-renderer';
-    const parent = select(target);
-    parent.select(`.${svgClass}`).remove();
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as SVGSVGElement;
 
-    this.root = parent
-      .append('svg')
-      .attr('class', svgClass)
+    this.root = select(svg)
+      .attr('class', ROOT_CLASS)
       .attr('viewBox', `0 0 ${size[0]} ${size[1]}`)
       .attr('top', 0)
       .attr('left', 0)
       .attr('width', size[0])
       .attr('height', size[1]);
     this.currentContainer = this.root;
+
+    if (target) {
+      select(target).select(`.${ROOT_CLASS}`).remove();
+      target.append(this.root.node());
+    }
   }
 
   useContainer(title: string) {

--- a/src/LegendRenderer/SvgOutput.ts
+++ b/src/LegendRenderer/SvgOutput.ts
@@ -93,10 +93,10 @@ export default class SvgOutput extends AbstractOutput {
     nodes.each(function() {
       const node = select(this);
       const text = node.select('text');
-      if (!(node.node() instanceof SVGElement)) {
+      if (!(node.node() instanceof SVGElement) || !text.size()) {
         return;
       }
-      const elem: Element = <Element> (node.node());
+      const elem: Element = <Element> (text.node());
       let width = elem.getBoundingClientRect().width;
       let adapted = false;
       while (width > maxWidth) {

--- a/src/fixtures/outputs.ts
+++ b/src/fixtures/outputs.ts
@@ -1,0 +1,51 @@
+import AbstractOutput from '../LegendRenderer/AbstractOutput';
+
+export function makeSampleOutput(output: AbstractOutput) {
+  output.useContainer('My Container');
+  output.addTitle('Inside a container', 180, 180);
+  output.addLabel('An image in a container', 200, 220);
+  output.addImage('https://my-domain/image.png', 100, 50, 200, 250, false);
+  output.useRoot();
+  output.addTitle('Outside a container', 180, 480);
+  output.addLabel('An image', 200, 520);
+  output.addImage('https://my-domain/image2.png', 100, 50, 200, 550, true);
+}
+
+export const SAMPLE_OUTPUT_FINAL_HEIGHT = 600;
+
+export const SAMPLE_SVG =
+  '<svg class="geostyler-legend-renderer" viewBox="0 0 500 600" top="0" left="0" width="500" height="600" ' +
+  'xmlns="http://www.w3.org/2000/svg">' +
+  '<g class="legend-item" title="My Container">' +
+  '<g>' +
+  '<text class="legend-title" text-anchor="start" dx="180" dy="180">Inside a container</text>' +
+  '</g>' +
+  '<text x="200" y="220">An image in a container</text>' +
+  '<image x="200" y="250" width="100" height="50" href="https://my-domain/image.png"></image>' +
+  '</g>' +
+  '<g>' +
+  '<text class="legend-title" text-anchor="start" dx="180" dy="480">Outside a container</text>' +
+  '</g>' +
+  '<text x="200" y="520">An image</text>' +
+  '<rect x="200" y="550" width="100" height="50" style="fill-opacity: 0; stroke: black;"></rect>' +
+  '<image x="200" y="550" width="100" height="50" href="https://my-domain/image2.png"></image>' +
+  '</svg>';
+
+// max column width: 50, max column height: 200
+export const SAMPLE_SVG_COLUMN_CONSTRAINTS =
+  '<svg class="geostyler-legend-renderer" viewBox="0 0 500 700" top="0" left="0" width="500" height="700" ' +
+  'xmlns="http://www.w3.org/2000/svg">' +
+  '<g class="legend-item" title="My Container">' +
+  '<g>' +
+  '<text class="legend-title" text-anchor="start" dx="180" dy="180">Insid...</text>' +
+  '</g>' +
+  '<text x="200" y="220">An image in a container</text>' +
+  '<image x="200" y="250" width="100" height="50" href="https://my-domain/image.png"></image>' +
+  '</g>' +
+  '<g>' +
+  '<text class="legend-title" text-anchor="start" dx="180" dy="480">Outside a container</text>' +
+  '</g>' +
+  '<text x="200" y="520">An image</text>' +
+  '<rect x="200" y="550" width="100" height="50" style="fill-opacity: 0; stroke: black;"></rect>' +
+  '<image x="200" y="550" width="100" height="50" href="https://my-domain/image2.png"></image>' +
+  '</svg>';

--- a/src/fixtures/outputs.ts
+++ b/src/fixtures/outputs.ts
@@ -49,3 +49,229 @@ export const SAMPLE_SVG_COLUMN_CONSTRAINTS =
   '<rect x="200" y="550" width="100" height="50" style="fill-opacity: 0; stroke: black;"></rect>' +
   '<image x="200" y="550" width="100" height="50" href="https://my-domain/image2.png"></image>' +
   '</svg>';
+
+// as reported by jest-canvas-mock
+export const SAMPLE_PNG_EVENTS = [
+  {
+    'props': {
+      'value': '14px sans-serif'
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'font'
+  },
+  {
+    'props': {
+      'maxWidth': null as number,
+      'text': 'Inside a container',
+      'x': 180,
+      'y': 180
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'fillText'
+  },
+  {
+    'props': {
+      'maxWidth': null,
+      'text': 'An image in a container',
+      'x': 200,
+      'y': 220
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'fillText'
+  },
+  {
+    'props': {
+      'dHeight': 0,
+      'dWidth': 0,
+      'dx': 200,
+      'dy': 250,
+      'img': expect.any(Image),
+      'sHeight': 0,
+      'sWidth': 0,
+      'sx': 0,
+      'sy': 0
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'drawImage'
+  },
+  {
+    'props': {
+      'maxWidth': null,
+      'text': 'Outside a container',
+      'x': 180,
+      'y': 480
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'fillText'
+  },
+  {
+    'props': {
+      'maxWidth': null,
+      'text': 'An image',
+      'x': 200,
+      'y': 520
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'fillText'
+  },
+  {
+    'props': {
+      'dHeight': 0,
+      'dWidth': 0,
+      'dx': 200,
+      'dy': 550,
+      'img': expect.any(Image),
+      'sHeight': 0,
+      'sWidth': 0,
+      'sx': 0,
+      'sy': 0
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'drawImage'
+  },
+  {
+    'props': {
+      'height': 50,
+      'width': 100,
+      'x': 200,
+      'y': 550
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'strokeRect'
+  }
+];
+
+// events when starting with a height of 200
+export const SAMPLE_PNG_EVENTS_HEIGHT_TOO_LOW = [
+  {
+    'props': {
+      'value': '14px sans-serif'
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'font'
+  },
+  {
+    'props': {
+      'dHeight': 300,
+      'dWidth': 500,
+      'dx': 0,
+      'dy': 0,
+      'img': expect.any(HTMLCanvasElement),
+      'sHeight': 300,
+      'sWidth': 500,
+      'sx': 0,
+      'sy': 0
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'drawImage'
+  },
+  {
+    'props': {
+      'dHeight': 0,
+      'dWidth': 0,
+      'dx': 200,
+      'dy': 550,
+      'img': expect.any(Image),
+      'sHeight': 0,
+      'sWidth': 0,
+      'sx': 0,
+      'sy': 0
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'drawImage'
+  },
+  {
+    'props': {
+      'height': 50,
+      'width': 100,
+      'x': 200,
+      'y': 550
+    },
+    'transform': [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    'type': 'strokeRect'
+  }
+];


### PR DESCRIPTION
This PR refactors the `LegendRenderer` class to externalize all "rendering" logic (i.e. using D3 and SVG) to a separate `SvgOutput` class with atomic operations (add image, add label, etc.).

Then, another `PngOutput` class is added and `LegendRenderer` can essentially use both interchangeably. Also added a `renderAsImage` method to the `LegendRenderer` API in order to obtain an image without providing a container, useful when the legend is intended to be downloaded instead of being added to the DOM.

To use PNG output:

```js
const renderer = new LegendRenderer({
  // ...
});
renderer.render(target, 'png');

// or
const canvas = await renderer.renderAsImage('png'); // returns a HTMLCanvasElement
```

The important part is that **the default behavior of `LegendRenderer` (generating an SVG and appending it) is almost entirely unchanged**. The only difference is about the root svg namespace which is sometimes added when it was not before (see commits).

Caveat: labels are not shortened in the PNG output. This will need a bit more refactoring so I thought I'd leave that for later.

Remaining to do:
* rewrite tests
* add a small test app to compare different outputs side by side

Also I think it would be nice to set up some wider regression tests so that it's easier to add more features, e.g. automatic width adjustment, more options to customize layout, etc.!

Fixes #390 