### PR TITLE
Extends ol dependency range 

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "d3": "^6.7.0",
-    "ol": "^6.5.0"
+    "ol": "6 - 7"
   },
   "devDependencies": {
     "@babel/core": "^7.14.5",


### PR DESCRIPTION
This extends the ol peerDependency range to include v7.

Fixes #401 