### PR TITLE
fix: ensure style images are loaded before legend icons rendering

### DIFF
--- a/src/LegendRenderer/LegendRenderer.ts
+++ b/src/LegendRenderer/LegendRenderer.ts
@@ -3,6 +3,7 @@ import OlGeometry from 'ol/geom/Geometry';
 import OlGeomPoint from 'ol/geom/Point';
 import OlGeomPolygon from 'ol/geom/Polygon';
 import OlGeomLineString from 'ol/geom/LineString';
+import OlImageState from 'ol/ImageState';
 import OlStyle from 'ol/style/Style';
 import Renderer from 'ol/render/canvas/Immediate';
 import {
@@ -194,6 +195,7 @@ export class LegendRenderer {
         symbolizers: rule.symbolizers
       }]
     };
+
     return new Promise(async (resolve, reject) => {
       function drawGeoms(){
         geoms.forEach((geom: OlGeometry) => renderer.drawGeometry(geom));
@@ -207,11 +209,17 @@ export class LegendRenderer {
           olStyle = <OlStyle | OlStyle[]>olStyle(new OlFeature(geoms[0]), 1);
         }
         if (Array.isArray(olStyle)) {
+          // Trigger loading of all images and wait for them to complete loading
+          await Promise.all(olStyle.map((styleItem) => this.loadStyleImage(styleItem)));
+
           olStyle.forEach((styleItem: OlStyle) => {
             renderer.setStyle(styleItem);
             drawGeoms();
           });
         } else {
+          // Trigger loading of image and wait for it to complete loading
+          await this.loadStyleImage(olStyle);
+
           // @ts-expect-error TODO fix type errors
           renderer.setStyle(olStyle);
           drawGeoms();
@@ -222,6 +230,54 @@ export class LegendRenderer {
       }
     });
   };
+
+  /**
+    * Loads the image of a style item and resolves with true if loaded, false otherwise.
+    * @param {OlStyle} styleItem the style item to load
+    * @returns {Promise<boolean>} a promise resolving to true if the image is loaded, false otherwise
+    */
+  loadStyleImage = (styleItem?: OlStyle) => new Promise((resolve) => {
+    const imgLoaded = () => resolve(true);
+    const imgNotLoaded = () => resolve(false);
+
+    const styleItemImage = styleItem?.getImage();
+    if (!styleItemImage) {
+      return imgNotLoaded();
+    }
+
+    // If image is already loaded, resolve immediately
+    if (styleItemImage.getImageState() === OlImageState.LOADED) {
+      return imgLoaded();
+    }
+
+    const img = styleItemImage.getImage(1);
+
+    // Check if img is an HTMLImageElement before adding event listeners
+    if (img instanceof HTMLImageElement) {
+      const cleanup = () => {
+        img.removeEventListener('error', onError);
+        img.removeEventListener('load', onLoad);
+      };
+
+      const onError = () => {
+        cleanup();
+        imgNotLoaded();
+      };
+      const onLoad = () => {
+        cleanup();
+        imgLoaded();
+      };
+
+      img.addEventListener('error', onError);
+      img.addEventListener('load', onLoad);
+
+      styleItemImage.load();
+    } else {
+      // If img is HTMLCanvasElement | HTMLVideoElement | ImageBitmap, just resolve as not loaded
+      // TODO handle these cases properly
+      return imgNotLoaded();
+    }
+  });
 
   /**
    * Render a single legend.


### PR DESCRIPTION
I encountered the same issue than described in #442 while generating legends via https://github.com/camptocamp/inkmap

My proposition is heavily inspired by @rdewit POC :
https://github.com/geostyler/geostyler-legend/issues/442#issuecomment-2420953838